### PR TITLE
Add link to zachholman.com

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -3,7 +3,7 @@
 Left is a clean, whitespace-happy layout for [Jekyll](https://github.com/mojombo/jekyll).
 
 This is designed to be an easy layout to modify for your own blog. It was
-extracted from [zachholman.com][zh], which means it was battle-hardened from
+extracted from [zachholman.com](http://zachholman.com/), which means it was battle-hardened from
 years of posting serious blog posts about emoji and swear words.
 
 ![Left](http://cl.ly/image/3S2r1p2C0E2B/content)


### PR DESCRIPTION
This was missing the actual link. Looks like the `[]()` Markdown link format is used in most of the rest of the file, so I decided to go with that instead of finishing the existing `[][]` format.
