### PR TITLE
fix links in readme

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -26,14 +26,14 @@ my name to yours, my gravatar to yours, and so on.
 
 There's a few other places that don't have a TODO associated with them, too:
 
-- [CNAME](https://github.com/holman/left/blob/master/CNAME): If you're using
+- [CNAME](https://github.com/holman/left/blob/gh-pages/CNAME): If you're using
   this on GitHub Pages with a custom domain name, you'll want to change this
   to be the domain you're going to use. All that should be in here is a
   domain name on the first line and nothing else (like: `example.com`).
-- [favicon.ico](https://github.com/holman/left/blob/master/favicon.ico): This
+- [favicon.ico](https://github.com/holman/left/blob/gh-pages/favicon.ico): This
   is a smaller version of my gravatar for use as the icon in your browser's
   address bar. You should change it to whatever you'd like.
-- [apple-touch-icon.png](https://github.com/holman/left/blob/master/apple-touch-icon.png):
+- [apple-touch-icon.png](https://github.com/holman/left/blob/gh-pages/apple-touch-icon.png):
   Again, this is my gravatar, and it shows up in iOS and various other apps
   that use this file as an "icon" for your site.
 
@@ -48,7 +48,7 @@ should be able to see your new site at <http://username.github.com>.
 
 ## Licensing
 
-This is [MIT](https://github.com/holman/left/blob/master/LICENSE) with no
+This is [MIT](https://github.com/holman/left/blob/gh-pages/LICENSE) with no
 added caveats, so feel free to use this on your site without linking back to
 me or using a disclaimer or anything silly like that.
 


### PR DESCRIPTION
trivial / non-functional but prominent:

fixes links in `readme.markdown` so that they point to an existing branch: `s/master/gh-pages/`
