### PR TITLE
Update deprecated jekyll command

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -14,7 +14,7 @@ words.
 - Install Jekyll: `gem install jekyll`
 - [Fork this repository](https://github.com/holman/left/fork)
 - Clone it: `git clone https://github.com/YOUR-USER/left`
-- Run the jekyll server: `jekyll --server`
+- Run the jekyll server: `jekyll serve`
 
 You should have a server up and running locally at <http://localhost:4000>.
 


### PR DESCRIPTION
Changed `jekyll --server` to `jekyll serve`.
