### PR TITLE
Removed deprecated auto regen config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,6 @@
 markdown: rdiscount
 pygments: true
 permalink: /posts/:title
-auto: true
 rdiscount:
   extensions: [smart]
 


### PR DESCRIPTION
The current error with this config is:

```
Deprecation: Auto-regeneration can no longer be set from your configuration file(s). Use the --watch/-w command-line option instead.
```

http://jekyllrb.com/docs/upgrading/
