### PR TITLE
fixed github meta in layout

### DIFF
--- a/_layouts/layout.html
+++ b/_layouts/layout.html
@@ -41,7 +41,7 @@
     </section>
 
     <section class="meta">
-      <a href="https://github.com/{{ site.github.owner_name }}" target="_blank"><i class="fa fa-github"></i></a>
+      <a href="https://github.com/{{ site.github }}" target="_blank"><i class="fa fa-github"></i></a>
       <a href="https://twitter.com/{{ site.twitter }}" target="_blank"><i class="fa fa-twitter"></i></a>
       <a href="/atom.xml"><i class="fa fa-rss"></i></a>
     </section>


### PR DESCRIPTION
With site.github.owner_name it sends me to github main page(not my profile) even though I provided my username in _config.yml. With site.github it sends me to my profile page.
