### PR TITLE
Update gravatar site variable

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -18,7 +18,7 @@ layout: layout
     <h3>Discussion, links, and tweets</h3>
     <section class="copy">
       <a href="https://twitter.com/{{ site.twitter }}" target="_blank">
-        <img src="{{ site.gravatar_url }}?s=142" height="50" width="50" />
+        <img src="{{ site.github.owner_gravatar_url }}?s=142" height="50" width="50" />
       </a>
 
       <p>


### PR DESCRIPTION
Was not working for me with `site.gravatar_url`.  Noticed the different variable usage `site.github.owner_gravatar_url` in layout.html and used that.

And checked [Repository metadata on GitHub Pages](https://help.github.com/articles/repository-metadata-on-github-pages) to confirm.

:smiley:
