### PR TITLE
Fixes pygment warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 markdown: rdiscount
-highlighter: true
+highlighter: pygments
 permalink: /posts/:title
 rdiscount:
   extensions: [smart]

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 markdown: rdiscount
-pygments: true
+highlighter: true
 permalink: /posts/:title
 rdiscount:
   extensions: [smart]


### PR DESCRIPTION
Pygment has been giving me this warning recently:

```
Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'.
Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.
```
