### PR TITLE
Changed pygments to highlighter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 markdown: rdiscount
-pygments: true
+highlighter: pygments
 permalink: /posts/:title
 rdiscount:
   extensions: [smart]

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,4 @@
 markdown: rdiscount
-highlighter: pygments
 permalink: /posts/:title
 rdiscount:
   extensions: [smart]


### PR DESCRIPTION
Same change as in #28, but in one commit instead.

Pygment has been giving me this warning recently:

```
Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'.
Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.
```
