### PR TITLE
Add Jekyll and Proofer tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _site
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: ruby
+rvm:
+  - 2.1
+
+before_install:
+  - export NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+
+script:
+  - bundle exec jekyll build --drafts
+  - bundle exec htmlproof ./_site
+
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'jekyll'
+
+group :test do
+  gem 'html-proofer'
+end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Left
 
-Left is a clean, whitespace-happy layout for [Jekyll](https://github.com/mojombo/jekyll).
+[![Build Status](https://travis-ci.org/holman/left.svg?branch=master)](https://travis-ci.org/holman/left)
+
+Left is a clean, whitespace-happy layout for [Jekyll](https://github.com/jekyll/jekyll).
 
 This is designed to be an easy layout to modify for your own blog. It was
 extracted from [zachholman.com](http://zachholman.com/), which means it was

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,9 @@ rdiscount:
 gems:
   - jekyll-sitemap
 
+exclude:
+  - vendor
+
 name: Zach Holman
 url: http://zachholman.com
 description: A fantastic blog that is fantastic.


### PR DESCRIPTION
This adds a continuous testing with [Proofer](https://github.com/gjtorikian/html-proofer). 

> Proofer is a set of tests to validate your HTML output. These tests check if your image references are legitimate, if they have alt tags, if your internal links are working, and so on.

You must enable Travis to see it working.
