### PR TITLE
Ensure sitemap.xml does not show drafts

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,17 @@
+---
+layout: nil
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>{{ site.url }}</loc>
+    </url>
+    
+    {% for post in site.posts %}
+     {% unless post.draft %}
+     <url>
+         <loc>{{ site.url }}{{ post.url }}</loc>
+     </url>
+     {% endunless %}
+    {% endfor %}
+</urlset>


### PR DESCRIPTION
If you have any drafts in your _posts folder they will be added to the sitemap and potentially indexed by the bots
