### PR TITLE
Extract head and sidebar sections and put them in _includes folder

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,26 @@
+<head>
+  <meta charset="utf-8">
+  <title>
+    {% if page.title %}
+      {{ page.title }} &ndash;
+    {% endif %}
+    {{ site.name }}
+  </title>
+
+  <meta name="author" content="{{ site.name }}" />
+  <meta name="description" content="{{ site.description }}" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+
+  <link rel="alternate" type="application/rss+xml" href="/atom.xml" />
+
+  <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet" />
+  <link rel="stylesheet" href="{{ site.github.url }}/css/base.css" type="text/css" media="screen, projection" />
+  <link rel="stylesheet" href="{{ site.github.url }}/css/pygments.css" type="text/css" />
+  <link media="only screen and (max-device-width: 480px)" href="{{ site.github.url }}/css/mobile.css" type="text/css" rel="stylesheet" />
+  <link media="only screen and (device-width: 768px)" href="{{ site.github.url }}/css/mobile.css" type="text/css" rel="stylesheet" />
+  <link href='http://fonts.googleapis.com/css?family=Yanone+Kaffeesatz' rel='stylesheet' type='text/css'>
+  <link rel="apple-touch-icon" href="{{ site.github.url }}/apple-touch-icon.png" />
+
+  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+  <script type="text/javascript" src="{{ site.github.url }}/js/application.js"></script>
+</head>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,0 +1,25 @@
+<section class="sidebar">
+  <a href="/">
+    <img src="{{ site.github.owner_gravatar_url }}?s=150" height="75" width="75" class="avatar" />
+  </a>
+
+  <section class="name">
+    <a href="/">
+      <span id="fname">{{ site.name|split:' '|first }}</span>
+      <span id="lname">{{ site.name|split:' '|last }}</span>
+    </a>
+  </section>
+
+  <section class="meta">
+    <a href="{{ site.github.owner_url }}" target="_blank"><i class="fa fa-github"></i></a>
+    <a href="https://twitter.com/{{ site.twitter }}" target="_blank"><i class="fa fa-twitter"></i></a>
+    <a href="/atom.xml"><i class="fa fa-rss"></i></a>
+  </section>
+
+  <section class="sections">
+    <ul>
+      <li><a href="/about.html">about</a></li>
+      <li><a href="/">posts</a></li>
+    </ul>
+  </section>
+</section>

--- a/_layouts/layout.html
+++ b/_layouts/layout.html
@@ -1,32 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
-<head>
-  <meta charset="utf-8">
-  <title>
-    {% if page.title %}
-      {{ page.title }} &ndash;
-    {% endif %}
-    {{ site.name }}
-  </title>
-
-  <meta name="author" content="{{ site.name }}" />
-  <meta name="description" content="{{ site.description }}" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-
-  <link rel="alternate" type="application/rss+xml" href="/atom.xml" />
-
-  <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet" />
-  <link rel="stylesheet" href="{{ site.github.url }}/css/base.css" type="text/css" media="screen, projection" />
-  <link rel="stylesheet" href="{{ site.github.url }}/css/pygments.css" type="text/css" />
-  <link media="only screen and (max-device-width: 480px)" href="{{ site.github.url }}/css/mobile.css" type="text/css" rel="stylesheet" />
-  <link media="only screen and (device-width: 768px)" href="{{ site.github.url }}/css/mobile.css" type="text/css" rel="stylesheet" />
-  <link href='http://fonts.googleapis.com/css?family=Yanone+Kaffeesatz' rel='stylesheet' type='text/css'>
-  <link rel="apple-touch-icon" href="{{ site.github.url }}/apple-touch-icon.png" />
-
-  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
-  <script type="text/javascript" src="{{ site.github.url }}/js/application.js"></script>
-</head>
-
+{% include head.html %}
 <body>
   <section class="sidebar">
     <a href="/">

--- a/_layouts/layout.html
+++ b/_layouts/layout.html
@@ -2,32 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
 {% include head.html %}
 <body>
-  <section class="sidebar">
-    <a href="/">
-      <img src="{{ site.github.owner_gravatar_url }}?s=150" height="75" width="75" class="avatar" />
-    </a>
-
-    <section class="name">
-      <a href="/">
-        <span id="fname">{{ site.name|split:' '|first }}</span>
-        <span id="lname">{{ site.name|split:' '|last }}</span>
-      </a>
-    </section>
-
-    <section class="meta">
-      <a href="{{ site.github.owner_url }}" target="_blank"><i class="fa fa-github"></i></a>
-      <a href="https://twitter.com/{{ site.twitter }}" target="_blank"><i class="fa fa-twitter"></i></a>
-      <a href="/atom.xml"><i class="fa fa-rss"></i></a>
-    </section>
-
-    <section class="sections">
-      <ul>
-        <li><a href="/about.html">about</a></li>
-        <li><a href="/">posts</a></li>
-      </ul>
-    </section>
-  </section>
-
+  {% include sidebar.html %}
   {{ content }}
 </body>
 


### PR DESCRIPTION
Thanks for your theme. I have extracted these sections and put them in `_includes` folder. The `layout.html` is now cleaner I think. Users can customize the layout by includes their own sections, such as `footer.html` at the bottom.
